### PR TITLE
Implement Default for IndexList<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,18 @@ pub struct Index {
     generation: usize,
 }
 
+impl<T> Default for IndexList<T> {
+    fn default() -> Self {
+        IndexList {
+            contents: Default::default(),
+            generation: Default::default(),
+            next_free: Default::default(),
+            head: Default::default(),
+            tail: Default::default(),
+        }
+    }
+}
+
 impl<T> IndexList<T>
 where
     T: PartialEq,
@@ -196,13 +208,7 @@ where
     /// let list: IndexList<i32> = IndexList::new();
     /// ```
     pub fn new() -> IndexList<T> {
-        IndexList {
-            contents: Vec::new(),
-            generation: 0,
-            next_free: None,
-            head: None,
-            tail: None,
-        }
+        Self::default()
     }
 
     /// Creates a new `IndexList<T>` with a given capacity.


### PR DESCRIPTION
Clippy kept suggesting to add a `#[derive(Default)]`, but the custom derive for `Default` is naïve and requires that `T` implements it as well, when it's in fact not necessary.